### PR TITLE
use api specific endpoint to continue with homogeneous batch requests…

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ GmailBatchStream.prototype.pipeline = function(batchSize, quotaSize, filterError
       batch = [batch];
     }
     const batchRequestOptions = {
-      url: 'https://www.googleapis.com/batch',
+      url: 'https://www.googleapis.com/batch/gmail/v1',
       method: 'POST',
       headers: {
         'Content-Type': 'multipart/mixed',


### PR DESCRIPTION
… per https://developers.googleblog.com/2018/03/discontinuing-support-for-json-rpc-and.html

Homogenous batch requests that use the api specific endpoint will continue to be supported.